### PR TITLE
Switch to FastMCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Excel MCP Server
+
+This project exposes **FastMCP** tools to interact with a running Microsoft Excel instance. The server is intended to be called by an AI agent.
+
+Currently implemented:
+- `initialize_excel_link` tool to connect to Excel (requires Windows with pywin32).
+
+Run the server:
+```
+python -m excel_mcp.server
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,11 @@
+# Build TODO
+
+1. **Project setup and initialization** - create server skeleton with `initialize_excel_link` tool. *(Done)*
+2. Implement `get_formula` tool to retrieve a cell formula.
+3. Implement `trace_precedents` tool.
+4. Implement `trace_dependents` tool.
+5. Implement `find_cell_labels` tool and helper logic.
+6. Implement `build_label_address_map` function and tool.
+7. Add Excel event handling or polling.
+8. Integrate DuckDB for persistent storage.
+9. Write unit tests and examples.

--- a/excel_mcp/__init__.py
+++ b/excel_mcp/__init__.py
@@ -1,0 +1,3 @@
+from .server import server
+
+__all__ = ["server"]

--- a/excel_mcp/server.py
+++ b/excel_mcp/server.py
@@ -1,0 +1,42 @@
+from typing import Optional
+
+try:
+    import win32com.client as win32
+except ImportError:  # Not on Windows or pywin32 not installed
+    win32 = None
+
+from fastmcp.server import FastMCP
+
+# FastMCP server instance
+server = FastMCP(name="excel-mcp")
+
+excel_app = None
+
+@server.tool
+def initialize_excel_link(workbook: Optional[str] = None):
+    """Establish a connection to a running Excel instance or open a workbook."""
+    global excel_app
+    if win32 is None:
+        return {"status": "failure", "reason": "pywin32 not available"}
+
+    try:
+        excel_app = win32.GetActiveObject("Excel.Application")
+    except Exception:
+        excel_app = win32.Dispatch("Excel.Application")
+
+    if workbook:
+        excel_app.Workbooks.Open(workbook)
+
+    excel_app.Visible = True
+    wb = excel_app.ActiveWorkbook
+    ws = wb.ActiveSheet
+    return {
+        "status": "success",
+        "workbook": wb.Name,
+        "sheet": ws.Name,
+    }
+
+
+if __name__ == "__main__":
+    # Run server using HTTP transport by default
+    server.run(transport="streamable-http")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp
+pywin32; sys_platform == 'win32'
+duckdb


### PR DESCRIPTION
## Summary
- update server to use FastMCP instead of FastAPI
- update project requirements and README to reflect new framework
- expose initialization as a FastMCP tool
- revise TODO list wording

## Testing
- `pip install -r requirements.txt`
- `python -m excel_mcp.server` (server starts)


------
https://chatgpt.com/codex/tasks/task_e_684276517f40832790c548c67ad0f1ed