### PR TITLE
Integrate DuckDB storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Currently implemented:
 - `find_cell_labels` tool to guess human-readable labels for a cell.
 - `build_label_address_map` tool to map labels to data cell addresses.
 - Excel event monitoring tools to capture cell changes.
+- DuckDB persistence for label mappings (`initialize_database`, `query_label`).
 
 Run the server:
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -7,5 +7,5 @@
 5. Implement `find_cell_labels` tool and helper logic. *(Done)*
 6. Implement `build_label_address_map` function and tool. *(Done)*
 7. Add Excel event handling or polling. *(Done)*
-8. Integrate DuckDB for persistent storage.
+8. Integrate DuckDB for persistent storage. *(Done)*
 9. Write unit tests and examples.

--- a/excel_mcp/db.py
+++ b/excel_mcp/db.py
@@ -1,0 +1,49 @@
+import duckdb
+import time
+from typing import Dict, Optional, List, Tuple
+
+_db_conn: Optional[duckdb.DuckDBPyConnection] = None
+
+
+def init_db(path: str = "excel_mcp.db") -> None:
+    """Initialize DuckDB connection and create tables if needed."""
+    global _db_conn
+    _db_conn = duckdb.connect(path)
+    _db_conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS cell_labels(
+            label TEXT,
+            sheet_name TEXT,
+            cell_address TEXT,
+            last_updated TIMESTAMP,
+            PRIMARY KEY(label, sheet_name)
+        )
+        """
+    )
+
+
+def store_label_map(sheet_name: str, label_map: Dict[str, str]) -> None:
+    """Insert or update label mappings in the database."""
+    if _db_conn is None:
+        return
+    ts = time.time()
+    for label, addr in label_map.items():
+        _db_conn.execute(
+            "DELETE FROM cell_labels WHERE label = ? AND sheet_name = ?",
+            (label, sheet_name),
+        )
+        _db_conn.execute(
+            "INSERT INTO cell_labels VALUES (?, ?, ?, to_timestamp(?))",
+            (label, sheet_name, addr, ts),
+        )
+
+
+def query_label(label: str) -> List[Tuple[str, str]]:
+    """Return list of (sheet_name, cell_address) for a label."""
+    if _db_conn is None:
+        return []
+    rows = _db_conn.execute(
+        "SELECT sheet_name, cell_address FROM cell_labels WHERE label = ?",
+        (label,),
+    ).fetchall()
+    return [(r[0], r[1]) for r in rows]


### PR DESCRIPTION
## Summary
- implement DuckDB database module
- store label mappings in DuckDB and expose DB tools
- document database integration
- mark TODO item complete

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile excel_mcp/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68430ce0a5088327b9e5551a1bdd5415