### PR TITLE
Add unit tests and basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Run the server:
 ```
 python -m excel_mcp.server
 ```
+
+## Running Tests
+
+Unit tests are located in the `tests` directory and can be executed with:
+
+```
+python -m unittest discover -s tests
+```
+
+## Example
+
+A minimal example script is available in `examples/basic_usage.py` which starts
+the MCP server using the default HTTP transport.

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,8 @@
+"""Basic example demonstrating how to run the Excel MCP server."""
+
+from excel_mcp.server import server
+
+if __name__ == "__main__":
+    # This will start the FastMCP server using streamable HTTP transport.
+    # Connect to http://localhost:8000/ and call tools such as initialize_excel_link.
+    server.run(transport="streamable-http")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch
+from importlib import import_module
+
+# Import the actual module, not the server instance exposed in __init__
+server_mod = import_module('excel_mcp.server')
+
+
+class TestExcelEventSink(unittest.TestCase):
+    def test_event_sink_records_events(self):
+        sink = server_mod._ExcelEventSink()
+
+        class DummySheet:
+            def __init__(self, name):
+                self.Name = name
+
+        class DummyTarget:
+            def Address(self, row_abs, col_abs):
+                return "A1"
+
+        sheet = DummySheet("Sheet1")
+        target = DummyTarget()
+
+        sink.OnSheetChange(sheet, target)
+        sink.OnSheetCalculate(sheet)
+
+        self.assertEqual(len(sink.events), 2)
+        self.assertEqual(sink.events[0]["event"], "SheetChange")
+        self.assertEqual(sink.events[0]["address"], "Sheet1!A1")
+        self.assertEqual(sink.events[1]["event"], "SheetCalculate")
+
+
+class TestServerTools(unittest.TestCase):
+    def test_get_formula_no_win32(self):
+        with patch.object(server_mod, "win32", None):
+            result = server_mod.get_formula.fn(None, "A1")
+            self.assertEqual(result["status"], "failure")
+
+    def test_get_formula_not_initialized(self):
+        with patch.object(server_mod, "win32", object()):
+            with patch.object(server_mod, "excel_app", None):
+                result = server_mod.get_formula.fn(None, "A1")
+                self.assertEqual(result["status"], "failure")
+
+    def test_stop_event_monitor_not_running(self):
+        with patch.object(server_mod, "_event_thread", None):
+            result = server_mod.stop_excel_event_monitor.fn()
+            self.assertEqual(result["status"], "not_running")
+
+    def test_fetch_events_not_running(self):
+        with patch.object(server_mod, "_excel_event_handler", None):
+            result = server_mod.fetch_excel_events.fn()
+            self.assertEqual(result["status"], "failure")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add initial unit tests for server module
- include a basic usage example script
- update README with test instructions and example location

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_68430ce813208327a4922d67ced350cd