### PR TITLE
Add row context utility to utils

### DIFF
--- a/excel_mcp/utils.py
+++ b/excel_mcp/utils.py
@@ -1,5 +1,6 @@
 # Utility helper functions for Excel MCP
-from typing import List
+from typing import Dict, List, Any
+from openpyxl.utils.cell import coordinate_to_tuple, get_column_letter
 
 
 def _col_to_index(col: str) -> int:
@@ -10,15 +11,6 @@ def _col_to_index(col: str) -> int:
             continue
         idx = idx * 26 + (ord(ch) - ord('A') + 1)
     return idx
-
-
-def _index_to_col(idx: int) -> str:
-    """Convert a 1-based column index to Excel column letters."""
-    col = ""
-    while idx > 0:
-        idx, rem = divmod(idx - 1, 26)
-        col = chr(rem + ord("A")) + col
-    return col
 
 
 def address_within_ranges(target: str, ranges: List[str]) -> bool:
@@ -63,79 +55,148 @@ def address_within_ranges(target: str, ranges: List[str]) -> bool:
     return False
 
 
-def gather_row_context(rows: dict, start: str, text_limit: int = 3) -> dict:
-    """Collect outputs for cells near ``start`` in the same row.
+def gather_row_context(cells: Dict[str, Dict[str, Any]], anchor: str, text_limit: int = 3) -> Dict[str, Any]:
+    """Gather output values from cells in the same row as ``anchor``.
+
+    Scans left until ``text_limit`` consecutive non-formula and non-numeric
+    cells are encountered, then scans right until the next such cell or up
+    to 10 columns. Only addresses present in ``cells`` are returned.
 
     Parameters
     ----------
-    rows:
-        Mapping of cell addresses to dictionaries containing at least an
-        ``output`` entry and optionally a ``formula`` entry.
-    start:
-        Address of the reference cell (e.g. ``"B2"``).
+    cells:
+        Mapping of addresses to dictionaries with at least an ``output`` key and
+        optionally a ``formula`` key.
+    anchor:
+        Address like ``B5`` that serves as the starting point.
     text_limit:
-        Number of consecutive non-formula, non-numeric cells to allow when
-        scanning left from ``start``.
+        Number of consecutive text cells allowed when scanning left.
 
     Returns
     -------
-    dict
-        Mapping of addresses to the stored ``output`` values for the scanned
-        cells.
+    Dict[str, Any]
+        Addresses mapped to their output values.
     """
 
-    def _is_number(val) -> bool:
+    def _is_number(val: Any) -> bool:
         try:
             float(val)
             return True
         except (ValueError, TypeError):
             return False
 
-    start = start.strip("$")
-    col_part = "".join(filter(str.isalpha, start))
-    row_part = int("".join(filter(str.isdigit, start)))
-    start_idx = _col_to_index(col_part)
+    anchor = anchor.strip("$")
+    row_idx, col_idx = coordinate_to_tuple(anchor)
 
-    with_output = {k: v for k, v in rows.items() if v.get("output") is not None}
+    valid = {k: v for k, v in cells.items() if v.get("output") is not None}
 
-    results = {}
+    result: Dict[str, Any] = {}
 
-    # Scan left from the start cell
     consecutive_text = 0
-    idx = start_idx - 1
-    checked = 0
-    while idx >= 1 and checked < 100:
-        addr = f"{_index_to_col(idx)}{row_part}"
-        if addr in with_output:
-            info = with_output[addr]
-            results[addr] = info["output"]
-            checked += 1
+    idx = col_idx - 1
+    inspected = 0
+    while idx >= 1 and inspected < 100:
+        addr = f"{get_column_letter(idx)}{row_idx}"
+        if addr in valid:
+            info = valid[addr]
+            result[addr] = info["output"]
+            inspected += 1
             if "formula" not in info and not _is_number(info["output"]):
                 consecutive_text += 1
                 if consecutive_text >= text_limit:
                     break
         idx -= 1
 
-    # Include the start cell if present
-    start_cell = f"{col_part}{row_part}"
-    if start_cell in rows:
-        results[start_cell] = rows[start_cell].get("output")
+    if anchor in cells:
+        result[anchor] = cells[anchor].get("output")
 
-    # Scan to the right of the start cell
-    idx = start_idx + 1
-    if rows:
-        max_idx = max(_col_to_index("".join(filter(str.isalpha, k))) for k in rows.keys())
-    else:
-        max_idx = start_idx
+    max_idx = max((coordinate_to_tuple(a)[1] for a in valid), default=col_idx)
+    idx = col_idx + 1
     added = 0
     while idx <= max_idx and added < 10:
-        addr = f"{_index_to_col(idx)}{row_part}"
-        if addr in with_output:
-            info = with_output[addr]
-            results[addr] = info["output"]
+        addr = f"{get_column_letter(idx)}{row_idx}"
+        if addr in valid:
+            info = valid[addr]
+            result[addr] = info["output"]
             added += 1
             if "formula" not in info and not _is_number(info["output"]):
-                return results
+                break
         idx += 1
 
-    return results
+    return result
+
+
+def collect_column_outputs(cells: Dict[str, Dict[str, Any]], anchor: str, text_limit: int = 3) -> Dict[str, Any]:
+    """Gather output values from cells in the same column as ``anchor``.
+
+    Scans upward until ``text_limit`` consecutive non-formula and non-numeric
+    cells are encountered, then scans downward until the next such cell or up
+    to 10 rows. Only addresses present in ``cells`` are returned.
+
+    Parameters
+    ----------
+    cells:
+        Mapping of addresses to dictionaries with at least an ``output`` key and
+        optionally a ``formula`` key.
+    anchor:
+        Address like ``A10`` that serves as the starting point.
+    text_limit:
+        Number of consecutive text cells allowed when scanning upward.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Addresses mapped to their output values.
+    """
+
+    row, col_idx = coordinate_to_tuple(anchor)
+    column = get_column_letter(col_idx)
+
+    valid = {k: v for k, v in cells.items() if v.get("output") is not None}
+
+    result: Dict[str, Any] = {}
+
+    consecutive_text = 0
+    current = row - 1
+    inspected = 0
+    while current >= 1 and inspected < 100:
+        addr = f"{column}{current}"
+        if addr in valid:
+            info = valid[addr]
+            result[addr] = info["output"]
+            inspected += 1
+            if "formula" not in info:
+                try:
+                    float(info["output"])
+                    is_number = True
+                except (ValueError, TypeError):
+                    is_number = False
+                if not is_number:
+                    consecutive_text += 1
+                    if consecutive_text >= text_limit:
+                        break
+        current -= 1
+
+    if anchor in cells:
+        result[anchor] = cells[anchor].get("output")
+
+    max_row = max((coordinate_to_tuple(a)[0] for a in valid), default=row)
+    current = row + 1
+    added = 0
+    while current <= max_row and added < 10:
+        addr = f"{column}{current}"
+        if addr in valid:
+            info = valid[addr]
+            result[addr] = info["output"]
+            added += 1
+            if "formula" not in info:
+                try:
+                    float(info["output"])
+                    is_number = True
+                except (ValueError, TypeError):
+                    is_number = False
+                if not is_number:
+                    break
+        current += 1
+
+    return result

--- a/excel_mcp/utils.py
+++ b/excel_mcp/utils.py
@@ -12,6 +12,15 @@ def _col_to_index(col: str) -> int:
     return idx
 
 
+def _index_to_col(idx: int) -> str:
+    """Convert a 1-based column index to Excel column letters."""
+    col = ""
+    while idx > 0:
+        idx, rem = divmod(idx - 1, 26)
+        col = chr(rem + ord("A")) + col
+    return col
+
+
 def address_within_ranges(target: str, ranges: List[str]) -> bool:
     """Check if an address is contained within any sheet range.
 
@@ -52,3 +61,81 @@ def address_within_ranges(target: str, ranges: List[str]) -> bool:
             if start_idx <= tgt_col_idx <= end_idx:
                 return True
     return False
+
+
+def gather_row_context(rows: dict, start: str, text_limit: int = 3) -> dict:
+    """Collect outputs for cells near ``start`` in the same row.
+
+    Parameters
+    ----------
+    rows:
+        Mapping of cell addresses to dictionaries containing at least an
+        ``output`` entry and optionally a ``formula`` entry.
+    start:
+        Address of the reference cell (e.g. ``"B2"``).
+    text_limit:
+        Number of consecutive non-formula, non-numeric cells to allow when
+        scanning left from ``start``.
+
+    Returns
+    -------
+    dict
+        Mapping of addresses to the stored ``output`` values for the scanned
+        cells.
+    """
+
+    def _is_number(val) -> bool:
+        try:
+            float(val)
+            return True
+        except (ValueError, TypeError):
+            return False
+
+    start = start.strip("$")
+    col_part = "".join(filter(str.isalpha, start))
+    row_part = int("".join(filter(str.isdigit, start)))
+    start_idx = _col_to_index(col_part)
+
+    with_output = {k: v for k, v in rows.items() if v.get("output") is not None}
+
+    results = {}
+
+    # Scan left from the start cell
+    consecutive_text = 0
+    idx = start_idx - 1
+    checked = 0
+    while idx >= 1 and checked < 100:
+        addr = f"{_index_to_col(idx)}{row_part}"
+        if addr in with_output:
+            info = with_output[addr]
+            results[addr] = info["output"]
+            checked += 1
+            if "formula" not in info and not _is_number(info["output"]):
+                consecutive_text += 1
+                if consecutive_text >= text_limit:
+                    break
+        idx -= 1
+
+    # Include the start cell if present
+    start_cell = f"{col_part}{row_part}"
+    if start_cell in rows:
+        results[start_cell] = rows[start_cell].get("output")
+
+    # Scan to the right of the start cell
+    idx = start_idx + 1
+    if rows:
+        max_idx = max(_col_to_index("".join(filter(str.isalpha, k))) for k in rows.keys())
+    else:
+        max_idx = start_idx
+    added = 0
+    while idx <= max_idx and added < 10:
+        addr = f"{_index_to_col(idx)}{row_part}"
+        if addr in with_output:
+            info = with_output[addr]
+            results[addr] = info["output"]
+            added += 1
+            if "formula" not in info and not _is_number(info["output"]):
+                return results
+        idx += 1
+
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastmcp
 pywin32; sys_platform == 'win32'
 duckdb
+openpyxl

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from excel_mcp.utils import address_within_ranges
+from excel_mcp.utils import address_within_ranges, gather_row_context
 
 
 class TestAddressWithinRanges(unittest.TestCase):
@@ -14,6 +14,31 @@ class TestAddressWithinRanges(unittest.TestCase):
     def test_sheet_mismatch(self):
         ranges = ["Sheet1!A1:C3"]
         self.assertFalse(address_within_ranges("Sheet2!A1", ranges))
+
+
+class TestGatherRowContext(unittest.TestCase):
+    def test_scan_left_and_stop_right_on_text(self):
+        data = {
+            "A1": {"output": "a"},
+            "B1": {"output": "b"},
+            "C1": {"output": 3},
+            "D1": {"output": 4, "formula": "=4"},
+            "E1": {"output": "stop"},
+        }
+        result = gather_row_context(data, "C1")
+        expected = {"B1": "b", "A1": "a", "C1": 3, "D1": 4, "E1": "stop"}
+        self.assertEqual(result, expected)
+
+    def test_left_limit(self):
+        data = {
+            "A2": {"output": "x"},
+            "B2": {"output": "y"},
+            "C2": {"output": "z"},
+            "D2": {"output": 10},
+        }
+        result = gather_row_context(data, "D2")
+        expected = {"C2": "z", "B2": "y", "A2": "x", "D2": 10}
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
 import unittest
-from excel_mcp.utils import address_within_ranges, gather_row_context
+from excel_mcp.utils import (
+    address_within_ranges,
+    collect_column_outputs,
+    gather_row_context,
+)
 
 
 class TestAddressWithinRanges(unittest.TestCase):
@@ -38,6 +42,27 @@ class TestGatherRowContext(unittest.TestCase):
         }
         result = gather_row_context(data, "D2")
         expected = {"C2": "z", "B2": "y", "A2": "x", "D2": 10}
+        self.assertEqual(result, expected)
+
+
+class TestCollectColumnOutputs(unittest.TestCase):
+    def test_basic_scan(self):
+        cells = {
+            "A1": {"output": "Header"},
+            "A2": {"output": 5},
+            "A3": {"output": "x", "formula": "=B1"},
+            "A4": {"output": 10},
+            "A5": {"output": "stop"},
+        }
+
+        result = collect_column_outputs(cells, "A4", text_limit=1)
+        expected = {
+            "A3": "x",
+            "A2": 5,
+            "A1": "Header",
+            "A4": 10,
+            "A5": "stop",
+        }
         self.assertEqual(result, expected)
 
 


### PR DESCRIPTION
## Summary
- implement `gather_row_context` in utils for scanning neighboring cells
- support column index conversion helper
- test the new utility

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c0bd056883278f10576d7c727087